### PR TITLE
Add support for Flax/Jax models

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ terminal:
 $ pip install scandeval[all]
 ```
 
-This will install all the model frameworks currently supported (`pytorch` and
-`spacy`). If you know you only need one of these, you can install a slimmer
+This will install all the model frameworks currently supported (`pytorch`,
+`spacy`, and `jax`). If you know you only need one of these, you can install a slimmer
 package like so:
 ```shell
 $ pip install scandeval[pytorch]

--- a/scandeval/benchmarks/abstract/base.py
+++ b/scandeval/benchmarks/abstract/base.py
@@ -251,11 +251,16 @@ class BaseBenchmark(ABC):
                 task = model_metadata['task']
 
         # Ensure that the framework is installed
+        from_flax = False
         try:
-            if framework == 'pytorch':
+            if framework in ('pytorch', 'jax'):
                 import torch
                 import torch.nn as nn
                 from torch.nn import Parameter
+                if framework == 'jax':
+                    from_flax = True
+                    import jax
+                    framework = 'pytorch'
             elif framework == 'spacy':
                 import spacy
 
@@ -304,7 +309,8 @@ class BaseBenchmark(ABC):
                     model_cls = self._get_model_class(framework=framework)
                     model = model_cls.from_pretrained(model_id,
                                                       config=config,
-                                                      cache_dir=self.cache_dir)
+                                                      cache_dir=self.cache_dir,
+                                                      from_flax=from_flax)
 
                 # Get the `label2id` and `id2label` conversions from the model
                 # config

--- a/scandeval/benchmarks/abstract/base.py
+++ b/scandeval/benchmarks/abstract/base.py
@@ -719,7 +719,7 @@ class BaseBenchmark(ABC):
                       if 'tag-red' in a['class']]
 
         # Set up the order of the frameworks
-        valid_frameworks = ['pytorch', 'spacy']
+        valid_frameworks = ['pytorch', 'spacy', 'jax']
 
         # Extract a single valid framework in which the model has been
         # implemented

--- a/scandeval/benchmarks/abstract/base.py
+++ b/scandeval/benchmarks/abstract/base.py
@@ -805,7 +805,7 @@ class BaseBenchmark(ABC):
                 torch.manual_seed(4242)
                 torch.cuda.manual_seed_all(4242)
                 torch.backends.cudnn.benchmark = False
-
+            framework = 'pytorch'
             # Extract the model and tokenizer
             model = model_dict['model']
             tokenizer = model_dict['tokenizer']

--- a/scandeval/benchmarks/abstract/base.py
+++ b/scandeval/benchmarks/abstract/base.py
@@ -797,7 +797,7 @@ class BaseBenchmark(ABC):
         # Get bootstrap sample indices
         test_bidxs = rng.integers(0, len(test), size=(9, len(test)))
 
-        if framework in ['pytorch']:
+        if framework in ['pytorch', 'jax']:
 
             # Set platform-dependent random seeds
             if framework == 'pytorch':

--- a/scandeval/benchmarks/abstract/base.py
+++ b/scandeval/benchmarks/abstract/base.py
@@ -227,7 +227,7 @@ class BaseBenchmark(ABC):
                 model.
             framework (str or None, optional):
                 The framework the model has been built in. Currently supports
-                'pytorch' and 'spacy'. If None then this will be inferred from
+                'pytorch', 'jax', and 'spacy'. If None then this will be inferred from
                 `model_id`. Defaults to None.
             task (str or None, optional):
                 The task for which the model was trained on. If None then this
@@ -797,15 +797,15 @@ class BaseBenchmark(ABC):
         # Get bootstrap sample indices
         test_bidxs = rng.integers(0, len(test), size=(9, len(test)))
 
-        if framework in ['pytorch', 'jax']:
+        if framework in ('pytorch', 'jax'):
+            framework = 'pytorch'
 
             # Set platform-dependent random seeds
-            if framework == 'pytorch':
-                import torch
-                torch.manual_seed(4242)
-                torch.cuda.manual_seed_all(4242)
-                torch.backends.cudnn.benchmark = False
-            framework = 'pytorch'
+            import torch
+            torch.manual_seed(4242)
+            torch.cuda.manual_seed_all(4242)
+            torch.backends.cudnn.benchmark = False
+            
             # Extract the model and tokenizer
             model = model_dict['model']
             tokenizer = model_dict['tokenizer']

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from bump_version import get_current_version
 
 PYTORCH_REQUIRES = ['torch>=1.6.0']
+JAX_REQUIRES = PYTORCH_REQUIRES + ['jaxlib>=0.1.75', 'jax>=0.2.26', 'flax>=0.3.6']
 SPACY_REQUIRES = ['spacy>=3.2.0', 'spacy-transformers>=1.1.0']
 ALL_REQUIRES = (PYTORCH_REQUIRES +
                 SPACY_REQUIRES)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ PYTORCH_REQUIRES = ['torch>=1.6.0']
 JAX_REQUIRES = PYTORCH_REQUIRES + ['jaxlib>=0.1.75', 'jax>=0.2.26', 'flax>=0.3.6']
 SPACY_REQUIRES = ['spacy>=3.2.0', 'spacy-transformers>=1.1.0']
 ALL_REQUIRES = (PYTORCH_REQUIRES +
+                JAX_REQUIRES +
                 SPACY_REQUIRES)
 
 setup(name='scandeval',

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(name='scandeval',
                         'termcolor>=1.0.0'],
       extras_require=dict(pytorch=PYTORCH_REQUIRES,
                           spacy=SPACY_REQUIRES,
+                          jax=JAX_REQUIRES,
                           all=ALL_REQUIRES),
       entry_points=dict(console_scripts=['scandeval=scandeval.cli:benchmark']))


### PR DESCRIPTION
This PR adds support for benchmarking/finetuning models in Flax/Jax format (marked with the "JAX" tag in the 🤗 /Hub) via on-the-fly conversion to PyTorch. In the future, Huggingface might add native Jax support in the Trainer, for now conversion is the quickest way to use Flax/Jax models