### PR TITLE
option to fix embedding / ability to override model config

### DIFF
--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -32,7 +32,7 @@ def build_benchmark_config(
         model_language (None, str or sequence of str, optional):
             The language codes of the languages to include for models. If specified
             then this overrides the `language` parameter for model languages.
-        model_framework (None, str, optional):
+        model_framework (str, optional):
             The model framework to use. Only relevant if `model-id` refers to a local path.
             Otherwise, the framework will be set automatically.
         dataset_language (None, str or sequence of str, optional):

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -20,6 +20,8 @@ def build_benchmark_config(
     progress_bar: bool,
     save_results: bool,
     verbose: bool,
+    fix_embedding: bool,
+    override_model_config: Optional[dict],
 ) -> BenchmarkConfig:
     """Create a benchmark configuration.
 
@@ -58,6 +60,15 @@ def build_benchmark_config(
             'scandeval_benchmark_results.json'.
         verbose (bool, optional):
             Whether to output additional output.
+        fix_embedding (bool, optional):
+            Whether to increase the size of the model embedding to the size of the
+            tokenizer vocabulary, if needed.
+        override_model_config (dict, optional):
+            Override model config from HF Hub with revision, framework, task and
+            languages. This parameter is expected to be a dictionary mapping
+            a string defining the model id to a dictionary mapping revision, framework,
+            and task to appropriate strings and languages to a list of strings
+            with language codes.
     """
     # Prepare the languages
     languages = prepare_languages(language=language)
@@ -90,6 +101,8 @@ def build_benchmark_config(
         progress_bar=progress_bar,
         save_results=save_results,
         verbose=verbose,
+        fix_embedding=fix_embedding,
+        override_model_config=override_model_config,
     )
 
 

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -32,6 +32,9 @@ def build_benchmark_config(
         model_language (None, str or sequence of str, optional):
             The language codes of the languages to include for models. If specified
             then this overrides the `language` parameter for model languages.
+        model_framework (None, str, optional):
+            The model framework to use. Only relevant if `model-id` refers to a local path.
+            Otherwise, the framework will be set automatically.
         dataset_language (None, str or sequence of str, optional):
             The language codes of the languages to include for datasets. If
             specified then this overrides the `language` parameter for dataset
@@ -59,15 +62,6 @@ def build_benchmark_config(
             'scandeval_benchmark_results.json'.
         verbose (bool, optional):
             Whether to output additional output.
-        fix_embedding (bool, optional):
-            Whether to increase the size of the model embedding to the size of the
-            tokenizer vocabulary, if needed.
-        override_model_config (dict, optional):
-            Override model config from HF Hub with revision, framework, task and
-            languages. This parameter is expected to be a dictionary mapping
-            a string defining the model id to a dictionary mapping revision, framework,
-            and task to appropriate strings and languages to a list of strings
-            with language codes.
     """
     # Prepare the languages
     languages = prepare_languages(language=language)

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -20,8 +20,7 @@ def build_benchmark_config(
     progress_bar: bool,
     save_results: bool,
     verbose: bool,
-    fix_embedding: bool,
-    override_model_config: Optional[dict],
+    model_framework: Optional[str],
 ) -> BenchmarkConfig:
     """Create a benchmark configuration.
 
@@ -101,8 +100,7 @@ def build_benchmark_config(
         progress_bar=progress_bar,
         save_results=save_results,
         verbose=verbose,
-        fix_embedding=fix_embedding,
-        override_model_config=override_model_config,
+        model_framework=model_framework,
     )
 
 

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -93,7 +93,7 @@ def get_local_model_config(
                                    "local model `{model_id}`! "
                                    "Please use the --model-framework option.")
         logger.info(
-            f"Assuming 'pytroch' as the framework for local model `{model_id}`! "
+            f"Assuming 'pytorch' as the framework for local model `{model_id}`! "
             "If this is in error, please use the --model-framework option to override."
         )
         framework = "pytorch"

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -482,7 +482,7 @@ class BenchmarkDataset(ABC):
                     from_flax=model_config.framework == "jax",
                     use_auth_token=self.benchmark_config.use_auth_token,
                     cache_dir=self.benchmark_config.cache_dir,
-                    fix_embedding=elf.benchmark_config.fix_embedding,
+                    fix_embedding=self.benchmark_config.fix_embedding,
                 )
 
             # Initialise compute_metrics function

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -482,6 +482,7 @@ class BenchmarkDataset(ABC):
                     from_flax=model_config.framework == "jax",
                     use_auth_token=self.benchmark_config.use_auth_token,
                     cache_dir=self.benchmark_config.cache_dir,
+                    fix_embedding=False,
                 )
 
             # Initialise compute_metrics function

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -113,9 +113,12 @@ class BenchmarkDataset(ABC):
                 If the extracted framework is not recognized.
         """
         # Fetch the model config
-        model_config = get_model_config(
-            model_id=model_id, benchmark_config=self.benchmark_config
-        )
+        if self.benchmark_config.override_model_config:
+            model_config = ModelConfig(model_id, **self.benchmark_config.override_model_config[model_id])
+        else:
+            model_config = get_model_config(
+                model_id=model_id, benchmark_config=self.benchmark_config
+            )
 
         # Set random seeds to enforce reproducibility of the randomly initialised
         # weights
@@ -133,6 +136,7 @@ class BenchmarkDataset(ABC):
             from_flax=model_config.framework == "jax",
             use_auth_token=self.benchmark_config.use_auth_token,
             cache_dir=self.benchmark_config.cache_dir,
+            fix_embedding=self.benchmark_config.fix_embedding
         )
 
         # Get the metadata

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -167,7 +167,7 @@ class BenchmarkDataset(ABC):
                 If the extracted framework is not recognized.
         """
         # Fetch the model config
-        model_configurator = _local_model_config if os.path.isdir(model_id) else get_model_config
+        model_configurator = get_local_model_config if os.path.isdir(model_id) else get_model_config
         model_config = model_configurator(
             model_id=model_id, benchmark_config=self.benchmark_config
         )

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -53,7 +53,7 @@ def _local_model_config(model_id: str, benchmark_config: BenchmarkConfig):
         if benchmark_config.raise_errors:
             raise RuntimeError(f"No framework specified for local model `{model_id}`!")
         framework = "pytorch"
-    model_config = ModelConfig(model_id=model_id, revision="local", framework=framework, task="unknown", languages=[])
+    model_config = ModelConfig(model_id=model_id, revision="main", framework=framework, task="fill-mask", languages=[])
     return model_config
 
 

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -482,7 +482,7 @@ class BenchmarkDataset(ABC):
                     from_flax=model_config.framework == "jax",
                     use_auth_token=self.benchmark_config.use_auth_token,
                     cache_dir=self.benchmark_config.cache_dir,
-                    fix_embedding=False,
+                    fix_embedding=elf.benchmark_config.fix_embedding,
                 )
 
             # Initialise compute_metrics function

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -93,7 +93,7 @@ class Benchmarker:
         use_auth_token: Union[bool, str] = False,
         ignore_duplicates: bool = True,
         verbose: bool = False,
-        fix_embedding: bool = False,
+        fix_embedding: bool = True,
         override_model_config: Optional[dict] = None,
     ) -> None:
         # Build benchmark configuration

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -63,6 +63,9 @@ class Benchmarker:
             to True.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
+        fix_embedding (bool, optional):
+            Whether to increase the size of the model embedding to the size of the
+            tokenizer vocabulary, if needed.
 
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.
@@ -90,6 +93,8 @@ class Benchmarker:
         use_auth_token: Union[bool, str] = False,
         ignore_duplicates: bool = True,
         verbose: bool = False,
+        fix_embedding: bool = False,
+        override_model_config: Optional[dict] = None,
     ) -> None:
         # Build benchmark configuration
         self.benchmark_config = build_benchmark_config(
@@ -105,6 +110,8 @@ class Benchmarker:
             progress_bar=progress_bar,
             save_results=save_results,
             verbose=verbose,
+            fix_embedding=fix_embedding,
+            override_model_config=override_model_config,
         )
 
         # Set attributes from arguments

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -36,6 +36,9 @@ class Benchmarker:
             The language codes of the languages to include for models. If specified
             then this overrides the `language` parameter for model languages. Defaults
             to None.
+        model_framework (None, str or sequence of str, optional):
+            The model framework to use. Only relevant if `model-id` refers to a local path.
+            Otherwise, the framework will be set automatically. Defaults to None.
         dataset_language (None, str or sequence of str, optional):
             The language codes of the languages to include for datasets. If specified
             then this overrides the `language` parameter for dataset languages.
@@ -93,8 +96,7 @@ class Benchmarker:
         use_auth_token: Union[bool, str] = False,
         ignore_duplicates: bool = True,
         verbose: bool = False,
-        fix_embedding: bool = True,
-        override_model_config: Optional[dict] = None,
+        model_framework: str = None,
     ) -> None:
         # Build benchmark configuration
         self.benchmark_config = build_benchmark_config(
@@ -110,8 +112,7 @@ class Benchmarker:
             progress_bar=progress_bar,
             save_results=save_results,
             verbose=verbose,
-            fix_embedding=fix_embedding,
-            override_model_config=override_model_config,
+            model_framework=model_framework,
         )
 
         # Set attributes from arguments

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -66,9 +66,6 @@ class Benchmarker:
             to True.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
-        fix_embedding (bool, optional):
-            Whether to increase the size of the model embedding to the size of the
-            tokenizer vocabulary, if needed.
 
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -147,6 +147,25 @@ from .languages import get_all_languages
     help="""Whether to skip evaluation of models which have already been evaluated,
     with scores lying in the 'scandeval_benchmark_results.jsonl' file.""",
 )
+@click.option(
+    "--fix-embedding/--no-fix-embedding",
+    "-f/-nf",
+    default=False,
+    show_default=True,
+    help="""Whether to increase the size of the model embedding to the size of the
+            tokenizer vocabulary, if needed."""
+)
+@click.option(
+    "--override-model-config",
+    "-o",
+    default=None,
+    show_default=True,
+    help="""Override model config from HF Hub with revision, framework, task and
+            languages. This parameter is expected to be a dictionary mapping
+            a string defining the model id to a dictionary mapping revision, framework,
+            and task to appropriate strings and languages to a list of strings
+            with language codes."""
+)
 def benchmark(
     model_id: Tuple[str],
     dataset: Tuple[str],
@@ -164,6 +183,8 @@ def benchmark(
     auth_token: str,
     ignore_duplicates: bool,
     verbose: bool = False,
+    fix_embedding: bool = False,
+    override_model_config: dict = None,
 ) -> None:
     """Benchmark pretrained language models on Scandinavian language tasks."""
 
@@ -176,6 +197,7 @@ def benchmark(
     dataset_tasks = None if len(dataset_task) == 0 else list(dataset_task)
     batch_size_int = int(batch_size)
     auth: Union[str, bool] = auth_token if auth_token != "" else use_auth_token
+    override_model_config = None if override_model_config is None else eval(override_model_config)
 
     # Initialise the benchmarker class
     benchmarker = Benchmarker(
@@ -192,6 +214,8 @@ def benchmark(
         use_auth_token=auth,
         ignore_duplicates=ignore_duplicates,
         cache_dir=cache_dir,
+        fix_embedding=fix_embedding,
+        override_model_config=override_model_config,
     )
 
     # Perform the benchmark evaluation

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -58,6 +58,16 @@ from .languages import get_all_languages
     will use the `language` value.""",
 )
 @click.option(
+    "--model-framework",
+    "-mf",
+    default=None,
+    show_default=True,
+    multiple=True,
+    type=click.Choice(["pytorch", "jax"]),
+    help="""The model framework to use. Only relevant if `model-id` refers to a local path.
+    Otherwise, the framework will be set automatically.""",
+)
+@click.option(
     "--dataset-language",
     "-dl",
     default=None,
@@ -147,25 +157,6 @@ from .languages import get_all_languages
     help="""Whether to skip evaluation of models which have already been evaluated,
     with scores lying in the 'scandeval_benchmark_results.jsonl' file.""",
 )
-@click.option(
-    "--fix-embedding/--no-fix-embedding",
-    "-f/-nf",
-    default=True,
-    show_default=True,
-    help="""Whether to increase the size of the model embedding to the size of the
-            tokenizer vocabulary, if needed."""
-)
-@click.option(
-    "--override-model-config",
-    "-o",
-    default=None,
-    show_default=True,
-    help="""Override model config from HF Hub with revision, framework, task and
-            languages. This parameter is expected to be a dictionary mapping
-            a string defining the model id to a dictionary mapping revision, framework,
-            and task to appropriate strings and languages to a list of strings
-            with language codes."""
-)
 def benchmark(
     model_id: Tuple[str],
     dataset: Tuple[str],
@@ -183,8 +174,7 @@ def benchmark(
     auth_token: str,
     ignore_duplicates: bool,
     verbose: bool = False,
-    fix_embedding: bool = True,
-    override_model_config: dict = None,
+    model_framework: str = None,
 ) -> None:
     """Benchmark pretrained language models on Scandinavian language tasks."""
 
@@ -197,7 +187,6 @@ def benchmark(
     dataset_tasks = None if len(dataset_task) == 0 else list(dataset_task)
     batch_size_int = int(batch_size)
     auth: Union[str, bool] = auth_token if auth_token != "" else use_auth_token
-    override_model_config = None if override_model_config is None else eval(override_model_config)
 
     # Initialise the benchmarker class
     benchmarker = Benchmarker(
@@ -214,8 +203,7 @@ def benchmark(
         use_auth_token=auth,
         ignore_duplicates=ignore_duplicates,
         cache_dir=cache_dir,
-        fix_embedding=fix_embedding,
-        override_model_config=override_model_config,
+        model_framework=model_framework,
     )
 
     # Perform the benchmark evaluation

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -62,7 +62,6 @@ from .languages import get_all_languages
     "-mf",
     default=None,
     show_default=True,
-    multiple=True,
     type=click.Choice(["pytorch", "jax"]),
     help="""The model framework to use. Only relevant if `model-id` refers to a local path.
     Otherwise, the framework will be set automatically.""",

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -150,7 +150,7 @@ from .languages import get_all_languages
 @click.option(
     "--fix-embedding/--no-fix-embedding",
     "-f/-nf",
-    default=False,
+    default=True,
     show_default=True,
     help="""Whether to increase the size of the model embedding to the size of the
             tokenizer vocabulary, if needed."""
@@ -183,7 +183,7 @@ def benchmark(
     auth_token: str,
     ignore_duplicates: bool,
     verbose: bool = False,
-    fix_embedding: bool = False,
+    fix_embedding: bool = True,
     override_model_config: dict = None,
 ) -> None:
     """Benchmark pretrained language models on Scandinavian language tasks."""

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -121,6 +121,8 @@ class BenchmarkConfig:
     save_results: bool
     verbose: bool
     testing: bool = False
+    fix_embedding: bool = False
+    override_model_config: dict = None
 
 
 @dataclass

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -1,7 +1,7 @@
 """Configuration classes used throughout the project."""
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 
 @dataclass

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -81,6 +81,8 @@ class BenchmarkConfig:
     Attributes:
         model_languages (sequence of Language objects):
             The languages of the models to benchmark.
+        model_framework (str):
+            The framework of the models to benchmark.
         dataset_languages (sequence of Language objects):
             The languages of the datasets in the benchmark.
         dataset_tasks (sequence of DatasetTask):
@@ -121,8 +123,7 @@ class BenchmarkConfig:
     save_results: bool
     verbose: bool
     testing: bool = False
-    fix_embedding: bool = False
-    override_model_config: dict = None
+    model_framework: str = None
 
 
 @dataclass

--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -37,7 +37,7 @@ def load_model(
     from_flax: bool,
     use_auth_token: Union[bool, str],
     cache_dir: str,
-    raise_errors: bool,
+    raise_errors: bool = False,
 ) -> Tuple[PreTrainedTokenizer, PreTrainedModel]:
     """Load a model.
 
@@ -66,6 +66,8 @@ def load_model(
             token.
         cache_dir (str):
             The directory to cache the model in.
+        raise_errors (bool, optional):
+            Whether to raise errors instead of trying to fix them silently.
 
     Returns:
         pair of (tokenizer, model):
@@ -361,7 +363,7 @@ def align_model_and_tokenizer(
             The model to fix.
         tokenizer (PreTrainedTokenizer):
             The tokenizer to fix.
-        raise_errors (bool):
+        raise_errors (bool, optional):
             Whether to raise errors instead of trying to fix them silently.
 
     Returns:

--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -407,7 +407,7 @@ def align_model_and_tokenizer(
     if hasattr(model.config, "vocab_size") and hasattr(tokenizer, "vocab_size"):
         if model.config.vocab_size < tokenizer.vocab_size:
             if fix_embedding:
-                model.resize_token_embeddings(tokenizer.vocab_size+1)
+                model.resize_token_embeddings(new_num_tokens=tokenizer.vocab_size+1)
             else:
                 raise InvalidBenchmark(
                     "The vocab size of the tokenizer is larger than the vocab size of the "

--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -361,6 +361,8 @@ def align_model_and_tokenizer(
             The model to fix.
         tokenizer (PreTrainedTokenizer):
             The tokenizer to fix.
+        raise_errors (bool):
+            Whether to raise errors instead of trying to fix them silently.
 
     Returns:
         pair of (model, tokenizer):

--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -37,7 +37,7 @@ def load_model(
     from_flax: bool,
     use_auth_token: Union[bool, str],
     cache_dir: str,
-    fix_embedding: bool
+    raise_errors: bool,
 ) -> Tuple[PreTrainedTokenizer, PreTrainedModel]:
     """Load a model.
 
@@ -216,7 +216,7 @@ def load_model(
             raise InvalidBenchmark(f"Could not load tokenizer for model {model_id!r}.")
 
     # Align the model and the tokenizer
-    model, tokenizer = align_model_and_tokenizer(model=model, tokenizer=tokenizer, fix_embedding=fix_embedding)
+    model, tokenizer = align_model_and_tokenizer(model=model, tokenizer=tokenizer, raise_errors=raise_errors)
 
     return tokenizer, model
 
@@ -352,7 +352,7 @@ def setup_model_for_question_answering(model: PreTrainedModel) -> PreTrainedMode
 
 
 def align_model_and_tokenizer(
-    model: PreTrainedModel, tokenizer: PreTrainedTokenizer, fix_embedding: bool
+    model: PreTrainedModel, tokenizer: PreTrainedTokenizer, raise_errors: bool = False
 ) -> Tuple[PreTrainedModel, PreTrainedTokenizer]:
     """Aligns the model and the tokenizer.
 
@@ -406,13 +406,13 @@ def align_model_and_tokenizer(
     # the vocab size according to the model, we raise an error
     if hasattr(model.config, "vocab_size") and hasattr(tokenizer, "vocab_size"):
         if model.config.vocab_size < tokenizer.vocab_size:
-            if fix_embedding:
-                model.resize_token_embeddings(new_num_tokens=tokenizer.vocab_size+1)
-            else:
+            if raise_errors:
                 raise InvalidBenchmark(
                     "The vocab size of the tokenizer is larger than the vocab size of the "
-                    "model. This is not supported."
+                    "model. As the --raise-errors option was specified, the embeddings "
+                    "of the model will not be automatically adjusted."
                 )
+            model.resize_token_embeddings(new_num_tokens=tokenizer.vocab_size+1)
 
     # If the tokenizer does not have a padding token (e.g. GPT-2), we use find a
     # suitable padding token and set it

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -123,6 +123,7 @@ def benchmark_speed_single_iteration(
                 from_flax=model_config.framework == "jax",
                 use_auth_token=benchmark_config.use_auth_token,
                 cache_dir=benchmark_config.cache_dir,
+                raise_errors=benchmark_config.raise_errors,
             )
 
         # Ensure that the model is on the CPU

--- a/src/scripts/fill_in_missing_model_metadata.py
+++ b/src/scripts/fill_in_missing_model_metadata.py
@@ -78,6 +78,7 @@ def main() -> None:
                         from_flax=False,
                         use_auth_token=True,
                         cache_dir=".scandeval_cache",
+                        raise_errors=False,
                     )
 
                     # Add the metadata to the record


### PR DESCRIPTION
These changes add two optional parameters to scandeval. These parameters allow to use popular GPT-2-based models, as well as to provide local models (directories resulting from save_pretrained) that are not available on HF Hub (yet).

--fix-embedding
    Whether to increase the size of the model embedding to the size of the
    tokenizer vocabulary, if needed.

--override-model-config
    Override model config from HF Hub with revision, framework, task and
    languages. This parameter is expected to be a dictionary mapping
    a string defining the model id to a dictionary mapping revision, framework,
    and task to appropriate strings and languages to a list of strings
    with language codes.