### PR TITLE
left-padding-is-broken in tokenizers

### DIFF
--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -425,11 +425,11 @@ def align_model_and_tokenizer(
     # suitable padding token and set it
     if tokenizer.pad_token is None:
         if tokenizer.eos_token is not None:
-            tokenizer.padding_side = "left"
+            tokenizer.padding_side = "right"
             tokenizer.pad_token = tokenizer.eos_token
             model.config.pad_token_id = tokenizer.pad_token_id
         elif tokenizer.sep_token is not None:
-            tokenizer.padding_side = "left"
+            tokenizer.padding_side = "right"
             tokenizer.pad_token = tokenizer.sep_token
             model.config.pad_token_id = tokenizer.pad_token_id
         else:


### PR DESCRIPTION
question answering does not work with left padding due to an upstream issue in the fast tokenizers
[tokenizers issue #1229](https://github.com/huggingface/tokenizers/issues/1229)
this workaround should prevent scandeval from encountering this issue