### PR TITLE
Fix/do not use auto batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
 - Changed the `--use-auth-token` and `--auth-token` arguments to `--use-token` and
   `--token`, reflecting the same change in the `transformers` package.
 - Now reports all model parameters, rather than just the trainable ones.
+- Now uses 8-bit AdamW optimizer when CUDA is available rather than the default AdamW,
+  to save memory when working with larger models.
 
 ### Removed
 - Previously generative models had their maximum sequence length altered by subtracting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ and this project adheres to
 - Changed the `--use-auth-token` and `--auth-token` arguments to `--use-token` and
   `--token`, reflecting the same change in the `transformers` package.
 - Now reports all model parameters, rather than just the trainable ones.
-- Now uses 8-bit AdamW optimizer when CUDA is available rather than the default AdamW,
-  to save memory when working with larger models.
 
 ### Removed
 - Previously generative models had their maximum sequence length altered by subtracting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to
 - Changed the `--model-framework` argument to `--framework`.
 - Changed the `--use-auth-token` and `--auth-token` arguments to `--use-token` and
   `--token`, reflecting the same change in the `transformers` package.
-- Now uses the new `auto_find_batch_size` argument in `TrainingArguments`, rather than
-  manually doing this, as the underlying `accelerate` built-in version is more robust.
 - Now reports all model parameters, rather than just the trainable ones.
 
 ### Removed

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,13 +13,13 @@ files = [
 
 [[package]]
 name = "accelerate"
-version = "0.23.0"
+version = "0.24.1"
 description = "Accelerate"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "accelerate-0.23.0-py3-none-any.whl", hash = "sha256:fba5065ff4e7c8f0a39df50785023703cd9bf8388073aa13c6457920f3bc5225"},
-    {file = "accelerate-0.23.0.tar.gz", hash = "sha256:2139d219fa9a37773c4279c9afebe9f681f2f29e85a29b0be8d76257bd8e4abe"},
+    {file = "accelerate-0.24.1-py3-none-any.whl", hash = "sha256:866dec394da60e8da964be212379d8cf6cc0d0e5e28a7c0d7e09507715d21c61"},
+    {file = "accelerate-0.24.1.tar.gz", hash = "sha256:85ab2aeb4d06194b75113339f81b7d650523414a82c9e91b2912a655f53dfa8e"},
 ]
 
 [package.dependencies]

--- a/src/scandeval/finetuning.py
+++ b/src/scandeval/finetuning.py
@@ -365,11 +365,6 @@ def get_training_args(
     if batch_size is None:
         batch_size = benchmark_config.batch_size
 
-    if benchmark_config.device == torch.device("cuda"):
-        optimizer = OptimizerNames.ADAMW_8BIT
-    else:
-        optimizer = OptimizerNames.ADAMW_TORCH
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         training_args = TrainingArguments(
@@ -390,7 +385,7 @@ def get_training_args(
             warmup_ratio=0.01,
             gradient_accumulation_steps=32 // batch_size,
             load_best_model_at_end=True,
-            optim=optimizer,
+            optim=OptimizerNames.ADAMW_TORCH,
             seed=seed,
             fp16=benchmark_config.device == torch.device("cuda"),
             disable_tqdm=not benchmark_config.progress_bar,

--- a/src/scandeval/finetuning.py
+++ b/src/scandeval/finetuning.py
@@ -105,59 +105,82 @@ def finetune(
         # the single iteration call
         model_already_initialized = idx == 0
 
-        # Clear memory after first iteration
-        if not model_already_initialized:
+        # Run a loop here to deal with automatic reduction of batch size
+        while True:
+            # Clear GPU memory
+            if not model_already_initialized:
+                try:
+                    del model
+                except UnboundLocalError:
+                    pass
+                try:
+                    del tokenizer
+                except UnboundLocalError:
+                    pass
+                clear_memory()
+
             try:
-                del model
-            except UnboundLocalError:
-                pass
-            try:
-                del tokenizer
-            except UnboundLocalError:
-                pass
-            clear_memory()
+                test = tests[idx]
+                prepared_test = prepared_tests[idx]
+                assert isinstance(test, Dataset)
+                assert isinstance(prepared_test, Dataset)
 
-        test = tests[idx]
-        prepared_test = prepared_tests[idx]
-        assert isinstance(test, Dataset)
-        assert isinstance(prepared_test, Dataset)
+                # Re-block terminal output, as it gets unblocked by the `transformers`
+                # package before training
+                block_terminal_output()
 
-        # Re-block terminal output, as it gets unblocked by the
-        # `transformers` package before training
-        block_terminal_output()
+                training_args = get_training_args(
+                    benchmark_config=benchmark_config,
+                    model_config=model_config,
+                    iteration_idx=idx,
+                    batch_size=bs,
+                )
 
-        training_args = get_training_args(
-            benchmark_config=benchmark_config,
-            model_config=model_config,
-            iteration_idx=idx,
-            batch_size=bs,
-        )
+                itr_scores = finetune_single_iteration(
+                    iteration_idx=idx,
+                    model_config=model_config,
+                    train=train,
+                    prepared_train=prepared_train,
+                    prepared_val=prepared_val,
+                    test=test,
+                    prepared_test=prepared_test,
+                    training_args=training_args,
+                    benchmark_config=benchmark_config,
+                    dataset_config=dataset_config,
+                    data_collator=data_collator,
+                    compute_metrics=compute_metrics,
+                    tokenizer=tokenizer if model_already_initialized else None,
+                    model=model if model_already_initialized else None,
+                    trainer_class=trainer_class,
+                    evaluate_inputs_fn=evaluate_inputs_fn,
+                    preprocess_logits_for_metrics=preprocess_logits_for_metrics,
+                )
 
-        itr_scores = finetune_single_iteration(
-            iteration_idx=idx,
-            model_config=model_config,
-            train=train,
-            prepared_train=prepared_train,
-            prepared_val=prepared_val,
-            test=test,
-            prepared_test=prepared_test,
-            training_args=training_args,
-            benchmark_config=benchmark_config,
-            dataset_config=dataset_config,
-            data_collator=data_collator,
-            compute_metrics=compute_metrics,
-            tokenizer=tokenizer if model_already_initialized else None,
-            model=model if model_already_initialized else None,
-            trainer_class=trainer_class,
-            evaluate_inputs_fn=evaluate_inputs_fn,
-            preprocess_logits_for_metrics=preprocess_logits_for_metrics,
-        )
+                if "train" in itr_scores:
+                    logger.debug(
+                        f"Train scores for iteration {idx}: {itr_scores['train']}"
+                    )
+                    scores["train"].append(itr_scores["train"])
+                scores["test"].append(itr_scores["test"])
+                logger.debug(f"Test scores for iteration {idx}: {itr_scores['test']}")
 
-        if "train" in itr_scores:
-            logger.debug(f"Train scores for iteration {idx}: {itr_scores['train']}")
-            scores["train"].append(itr_scores["train"])
-        scores["test"].append(itr_scores["test"])
-        logger.debug(f"Test scores for iteration {idx}: {itr_scores['test']}")
+                break
+
+            except Exception as e:
+                breakpoint()
+                if "CUDA" not in str(e) and "out of memory" not in str(e):
+                    raise InvalidBenchmark(str(e))
+
+                if bs <= 1:
+                    raise InvalidBenchmark(
+                        "Could not benchmark the model, even with a batch size of 1!"
+                    )
+
+                model_already_initialized = False
+
+                # Half batch size, and raise error if we've reached 0
+                bs //= 2
+                logger.debug(f"Reduced batch size to {bs}")
 
     return scores
 
@@ -342,6 +365,11 @@ def get_training_args(
     if batch_size is None:
         batch_size = benchmark_config.batch_size
 
+    if benchmark_config.device == torch.device("cuda"):
+        optimizer = OptimizerNames.ADAMW_8BIT
+    else:
+        optimizer = OptimizerNames.ADAMW_TORCH
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         training_args = TrainingArguments(
@@ -353,6 +381,7 @@ def get_training_args(
             logging_steps=30,
             save_steps=30,
             max_steps=10_000 if not benchmark_config.testing else 10,
+            use_cpu=benchmark_config.testing,
             report_to=[],
             save_total_limit=1,
             per_device_train_batch_size=batch_size,
@@ -361,10 +390,9 @@ def get_training_args(
             warmup_ratio=0.01,
             gradient_accumulation_steps=32 // batch_size,
             load_best_model_at_end=True,
-            optim=OptimizerNames.ADAMW_TORCH,
+            optim=optimizer,
             seed=seed,
-            fp16=torch.cuda.is_available(),
-            auto_find_batch_size=True,
+            fp16=benchmark_config.device == torch.device("cuda"),
             disable_tqdm=not benchmark_config.progress_bar,
             ddp_find_unused_parameters=False,
         )


### PR DESCRIPTION
Previously the `auto_find_batch_size` parameter was used, which reduces batch size by 2x when CUDA OOM is encountered. The problem is that the corresponding `gradient_accumulation` parameter doesn't get doubled in this case, so we revert back to doing this manually instead.